### PR TITLE
Add parameter cron for disabling checks not useful when being instantiated by CRON

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ smart-ipv6-rotator.py run [-h] [--services {google}] [--external-ipv6-ranges EXT
 - `--skip-root`: Skip root check.
 - `--no-services`: Completely disable the --services flag.
 - `--ipv6range IPV6RANGE`: Your IPV6 range (e.g., 2407:7000:9827:4100::/64).
+- `--cron`: Do not check if the IPv6 address configured will work properly. Useful for CRON and when you know that the IPv6 range is correct.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Full detailed documentation: https://docs.invidious.io/ipv6-rotator/
    Twice a day (noon and midnight) is enough for YouTube servers. Also at the reboot of the server!  
    Example crontab (`crontab -e -u root`):
    ```
-   @reboot sleep 30s && python smart-ipv6-rotator.py run --ipv6range=YOURIPV6SUBNET/64
-   0 */12 * * * python smart-ipv6-rotator.py run --ipv6range=YOURIPV6SUBNET/64
+   @reboot sleep 30s && python smart-ipv6-rotator.py run --cron --ipv6range=YOURIPV6SUBNET/64
+   0 */12 * * * python smart-ipv6-rotator.py run --cron --ipv6range=YOURIPV6SUBNET/64
    ```  
    The `sleep` command is used in case your network takes too much time time to be ready.
 

--- a/smart_ipv6_rotator/__init__.py
+++ b/smart_ipv6_rotator/__init__.py
@@ -58,13 +58,6 @@ SHARED_OPTIONS = [
             "help": "Completely disables the --services flag.",
         },
     ),
-    (
-        "--cron",
-        {
-            "action": "store_true",
-            "help": "Disable useless checks when being instantiated by CRON.",
-        },
-    ),
 ]
 
 
@@ -94,6 +87,9 @@ def run(
         sys.exit(
             "[ERROR] Legacy database format detected! Please run `python smart-ipv6-rotator.py clean` using the old version of this script.\nhttps://github.com/iv-org/smart-ipv6-rotator"
         )
+
+    if cron is True:
+        print("[INFO] Running without checking if the IPv6 address configured will work properly.")
 
     root_check(skip_root)
     check_ipv6_connectivity()
@@ -150,7 +146,7 @@ def run(
 
     sleep(2)  # Need so that the linux kernel takes into account the new ipv6 route
 
-    if cron == False:
+    if cron is False:
 
         try:
             IPROUTE.route(
@@ -267,6 +263,12 @@ def main() -> None:
         "--ipv6range",
         help="Your IPV6 range. Example: 2407:7000:9827:4100::/64",
         required=True,
+    )
+    run_parser.add_argument(
+        "--cron",
+        action="store_true",
+        help="Disable useless checks when being instantiated by CRON.",
+        required=False,
     )
     run_parser.set_defaults(func=run)
 

--- a/smart_ipv6_rotator/__init__.py
+++ b/smart_ipv6_rotator/__init__.py
@@ -267,7 +267,7 @@ def main() -> None:
     run_parser.add_argument(
         "--cron",
         action="store_true",
-        help="Disable useless checks when being instantiated by CRON.",
+        help="Disable checks for IPV6 address configured. Useful when being instantiated by CRON and the IPv6 range configured is correct.",
         required=False,
     )
     run_parser.set_defaults(func=run)


### PR DESCRIPTION
This will help with these issues:
- https://github.com/iv-org/smart-ipv6-rotator/issues/13
- https://github.com/iv-org/smart-ipv6-rotator/issues/3

Basically, the HTTP check may not be useful if the script is launched by CRON because the HTTP check is only for telling people that their setup does not work.

People can disable this check by passing `--cron`.