### PR TITLE
Add a --not-preferred flag to set preferred_lft to 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ smart-ipv6-rotator.py run [-h] [--services {google}] [--external-ipv6-ranges EXT
 - `--no-services`: Completely disable the --services flag.
 - `--ipv6range IPV6RANGE`: Your IPV6 range (e.g., 2407:7000:9827:4100::/64).
 - `--cron`: Do not check if the IPv6 address configured will work properly. Useful for CRON and when you know that the IPv6 range is correct.
-- `--log-level {CRITICAL,FATAL,ERROR,WARN,WARNING,INFO,DEBUG,NOTSET}`: Sets log level
+- `--log-level {CRITICAL,FATAL,ERROR,WARN,WARNING,INFO,DEBUG,NOTSET}`: Sets log level.
+- `--not-preferred`: Set the preferred_lft of the IPv6 address to 0
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 requires-python = ">=3.9"
 dependencies = [
     "requests>=2.31.0",
-    "pyroute2==0.8.1",
+    "pyroute2>=0.9.1",
 ]
 authors = [
     {name = "unixfox"},

--- a/smart_ipv6_rotator/__init__.py
+++ b/smart_ipv6_rotator/__init__.py
@@ -101,6 +101,7 @@ def run(
     cron: bool = False,
     interface: str | None = None,
     gateway: str | None = None,
+    not_preferred: bool = False,
 ) -> None:
     """Run the IPv6 rotator process."""
 
@@ -114,6 +115,12 @@ def run(
         LOGGER.info(
             "Running without checking if the IPv6 address configured will work properly."
         )
+
+    if not_preferred is True:
+        preferred_value = 0
+    else:
+        # A value of None defaults to a preferred_lft of forever
+        preferred_value = None
 
     root_check(skip_root)
     check_ipv6_connectivity()
@@ -173,6 +180,7 @@ def run(
             index=default_interface_index,
             address=random_ipv6_address,
             mask=ipv6_network.prefixlen,
+            preferred=preferred_value,
         )
     except Exception as error:
         clean_ranges(service_ranges, skip_root)
@@ -323,6 +331,12 @@ def main() -> None:
     run_parser.add_argument(
         "--gateway",
         help="Specify the IPv6 gateway to use.",
+        required=False,
+    )
+    run_parser.add_argument(
+        "--not-preferred",
+        action="store_true",
+        help="Set the preferred_lft of the IPv6 address to 0.",
         required=False,
     )
     run_parser.set_defaults(func=run)

--- a/smart_ipv6_rotator/__init__.py
+++ b/smart_ipv6_rotator/__init__.py
@@ -170,7 +170,7 @@ def run(
     try:
         IPROUTE.addr(
             "add",
-            default_interface_index,
+            index=default_interface_index,
             address=random_ipv6_address,
             mask=ipv6_network.prefixlen,
         )

--- a/smart_ipv6_rotator/helpers.py
+++ b/smart_ipv6_rotator/helpers.py
@@ -124,7 +124,7 @@ def clean_ranges(ranges_: list[str], skip_root: bool) -> None:
     try:
         IPROUTE.addr(
             "del",
-            previous.interface_index,
+            index=previous.interface_index,
             address=previous.random_ipv6_address,
             mask=previous.random_ipv6_address_mask,
         )


### PR DESCRIPTION
This would close https://github.com/iv-org/smart-ipv6-rotator/issues/8.

I had to update to at least pyroute 0.9.1 since that's when they fixed the ability to use the `preferred` option when adding an address https://github.com/svinota/pyroute2/issues/752.

Not sure if you wanna keep the name of the flag or change it.

It'd also be pretty trivial to change this to let you set any preferred_lft instead.